### PR TITLE
Added alternative path for lapacke headers

### DIFF
--- a/Matrix/Makefile
+++ b/Matrix/Makefile
@@ -10,7 +10,7 @@ SHELL = /bin/sh
 OS_DIR = /usr/
 
 # compiler command to use
-CXXFLAGS = -std=c++11 -O3 -fPIC -pedantic -Wall -Wextra -I. -I../GeneralUtils/
+CXXFLAGS = -std=c++11 -O3 -fPIC -pedantic -Wall -Wextra -I. -I../GeneralUtils/ -I/usr/include/lapacke/
 
 WITH_LAPACKE = 1
 ifdef WITH_LAPACKE


### PR DESCRIPTION
On RHEL, the lapacke headers are installed in an alternate location that doesn't play nice with the existing makefile. This change fixes that without interfering with other installations